### PR TITLE
fix(magento-2.4.6): Add default cronjobs via CLI command.

### DIFF
--- a/apps/magento-2.4.6-offirepo-nginx-mysqlserver
+++ b/apps/magento-2.4.6-offirepo-nginx-mysqlserver
@@ -90,6 +90,11 @@ find var generated vendor pub/static pub/media app/etc -type d -exec chmod g+ws 
 chown -R www-data:www-data .
 chmod u+x bin/magento
 
+# Creating magento default cronjobs see https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/cli/configure-cron-jobs
+echo "Creating magento default cronjobs" | log
+cd $appPath
+sudo -u www-data bin/magento cron:install --force
+
 echo "Disabling sign static files and forcing cache refresh" | log
 cd $appPath
 php bin/magento cache:disable config | log


### PR DESCRIPTION
- The default cronjobs run every minute.
- The cron log file is in /var/log/magento.cron.log.